### PR TITLE
chore(plugins,docs): register legal + operations — bundles + asset counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ Claude Code, Cursor, GitHub Copilot, Codex, Gemini CLI, Windsurf 등 [Linux Foun
 
 | 자산 | 위치 | 개수 |
 |---|---|---|
-| Skills (도메인 패턴) | `.claude/skills/` | 220개 (Go, Java/Spring, K8s, MSA, observability, business 등 18 카테고리) |
+| Skills (도메인 패턴) | `.claude/skills/` | 233개 (Go, Java/Spring, K8s, MSA, observability, business, legal, operations 등 20 카테고리) |
 | Agents (전문 에이전트) | `.claude/agents/` | 46개 (database-expert, k8s-troubleshooter, saga-agent 등) |
 | Rules (코딩/보안/워크플로우) | `.claude/rules/` | 14개 (이 AGENTS.md의 상세판) |
-| Plugins (역할별 번들) | `plugins/*.yml` | 10 bundles |
+| Plugins (역할별 번들) | `plugins/*.yml` | 12 bundles |
 | Workflows (시나리오 번들) | `.claude/workflows/*.yml` | 7 scenarios |
 
 **중요**: K8s/Cloud/Monitoring 섹션의 룰은 **install된 프로젝트**에 적용된다 (이 메타 레포 자체엔 K8s 없음).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,11 +48,11 @@
 | **Plugins** | `plugins/*.yml` | `install.sh --plugin <name>` |
 | **Workflows** | `.claude/workflows/*.yml` | `install.sh --workflow <name>` |
 
-**현재 자산** (2026-04-19 기준):
-- Skills: 216개 (~83K줄), 17 카테고리
+**현재 자산** (2026-05-01 기준):
+- Skills: 233개 (~89K줄), 20 카테고리 (+ legal, operations 신설)
 - Agents: 46개 (~18K줄)
 - Commands: 43개
-- Plugins: 10 bundles
+- Plugins: 12 bundles (+ compliance, ops)
 - Workflows: 7 scenarios + `_base`
 
 상세 인덱스: [.claude/inventory.yml](.claude/inventory.yml)

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -23,7 +23,12 @@
 | backend-python | Python 백엔드 | 3 | 2 |
 | sre-full | SRE 전체 툴킷 | 6 | 4 |
 | ai-ml | AI/ML 번들 | 2 | 2 |
+| ai-engineering | AI-First 엔지니어링 (agentic, SDD, GenAI 관측) | 3 | 2 |
 | messaging | 메시징 시스템 | 2 | 1 |
+| frontend | 프론트엔드 (React/Next.js/디자인 시스템) | 1 | 1 |
+| strategy | 기술 전략 (RFC/ADR, migration, product thinking) | 3 | 1 |
+| **compliance** | **법적·컴플라이언스 (KR PIPA/위치정보법/아동, GDPR, DSR, audit)** | **3** | **2 + 3 individual** |
+| **ops** | **운영 표준화 (Runbook, 회고, 인시던트, on-call, SRE)** | **4** | **2 + 3 individual** |
 
 ## Plugin Manifest 형식
 

--- a/plugins/compliance.yml
+++ b/plugins/compliance.yml
@@ -1,0 +1,14 @@
+name: compliance
+description: "법적·컴플라이언스 운영 — 한국 위치정보법/PIPA/아동 보호, 글로벌 GDPR/SOC2/HIPAA, DSR 자동화, audit log"
+agents:
+  - compliance-auditor
+  - security-scanner
+  - tech-lead
+skills:
+  categories:
+    - legal
+    - security
+  individual:
+    - business/audit-log
+    - business/multi-tenancy
+    - observability/logging-compliance

--- a/plugins/ops.yml
+++ b/plugins/ops.yml
@@ -1,0 +1,15 @@
+name: ops
+description: "운영 표준화 번들 — Runbook 표준/실행 자동화, Blameless 회고, 인시던트 playbook, on-call, SRE 도구"
+agents:
+  - incident-responder
+  - k8s-troubleshooter
+  - debugging-expert
+  - tech-lead
+skills:
+  categories:
+    - operations
+    - sre
+  individual:
+    - observability/observability-incident-playbook
+    - observability/alerting-discord
+    - observability/aiops-remediation


### PR DESCRIPTION
## Summary

PR #7~#11 시리즈로 신설된 \`legal/\` + \`operations/\` 카테고리를 plugin 번들과 docs에 정식 등록.

- **plugins/compliance.yml** 신설 — \`legal/\` + \`security/\` 카테고리 + \`business/audit-log\`·\`multi-tenancy\`·\`observability/logging-compliance\` individual
- **plugins/ops.yml** 신설 — \`operations/\` + \`sre/\` + \`observability/observability-incident-playbook\`·\`alerting-discord\`·\`aiops-remediation\` individual
- **plugins/README.md 표 갱신** — 누락된 ai-engineering/frontend/strategy 포함 + 신규 2개 → **7개 → 12개 정확 표시**
- **AGENTS.md** 자산 카운트: 220 → 233 skills, 18 → 20 categories, 10 → 12 plugins
- **CLAUDE.md** 자산 카운트: 216 → 233 skills, 17 → 20 categories, 10 → 12 plugins (날짜 2026-04-19 → 2026-05-01)

## Test plan

- [ ] CI 4/4 (Documentation / Inventory / Shellcheck / Test)
- [ ] \`./install.sh --list-plugins\` 에 \`compliance\`, \`ops\` 표시 확인
- [ ] \`./install.sh --plugin compliance --with-skills\` dry-run 시 legal/ + security/ 카테고리 + 3개 individual skill 모두 포함

## Followup

- chore-B (#13): \`scripts/generate-inventory.sh\` frontmatter 파서 fix — credit-system, kr-location-info-act 등 7개 skill의 title이 \"---\"로 잘못 추출되는 버그

Closes #12
Related: #1, #2, #3, #4, #5, #13