### PR TITLE
fix(skills): correct OWASP K8s 2025 mapping and Glass attribution

### DIFF
--- a/.claude/skills/architecture/config-explicit-defaults.md
+++ b/.claude/skills/architecture/config-explicit-defaults.md
@@ -177,7 +177,7 @@ kubectl get deployment X -o jsonpath='{.spec.template.spec.containers[0].env}'
 ## 외부 근거
 
 - [12factor.net III: Config](https://12factor.net/config) — config 는 env 에 저장, code 와 분리
-- [Twelve-Factor Config: Misunderstandings and Advice — Kristian Glass](https://blog.doismellburning.co.uk/twelve-factor-config-misunderstandings-and-advice/) — "config sprawl" 명명
+- [Twelve-Factor Config: Misunderstandings and Advice — Kristian Glass](https://blog.doismellburning.co.uk/twelve-factor-config-misunderstandings-and-advice/) — 12-factor config 함정 정리
 - [OpenTelemetry SDK Configuration Spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)
 - [Viper docs — Working with environment variables](https://github.com/spf13/viper#working-with-environment-variables) — AutomaticEnv + SetDefault 의존 관계
 

--- a/.claude/skills/kubernetes/defense-in-depth-layers.md
+++ b/.claude/skills/kubernetes/defense-in-depth-layers.md
@@ -70,7 +70,7 @@ spec:
         drop: [ALL]
 ```
 
-### K02: Supply chain vulnerabilities
+### K04: Lack Of Cluster Level Policy Enforcement (Supply chain)
 
 ```yaml
 # ❌ unsigned image
@@ -98,7 +98,7 @@ spec:
         - keys: {publicKeys: "..."}
 ```
 
-### K03: Overly permissive RBAC
+### K02: Overly Permissive Authorization Configurations
 
 ```yaml
 # ❌ cluster-admin 부여
@@ -113,7 +113,7 @@ spec:
   verbs: ["get", "list", "watch"]
 ```
 
-### K06: Broken authentication
+### K09: Broken Authentication Mechanisms
 
 `ServiceAccount` token 자동 mount 비활성화:
 
@@ -122,9 +122,9 @@ spec:
   automountServiceAccountToken: false   # 명시적으로 필요한 Pod 만 mount
 ```
 
-### K08: Network segmentation
+### K05: Missing Network Segmentation Controls
 
-NetworkPolicy 3중 체크 (Goti 실사례에서 가장 빈도 높음):
+NetworkPolicy 3중 체크 (운영 환경에서 빈도 높음):
 
 ```yaml
 # ✅ 1. default deny ingress


### PR DESCRIPTION
## Summary

PR #18 후속 hotfix. 외부 검증(WebFetch)으로 두 건의 사실 오류 확인 후 정정.

## Changes

### M5 `defense-in-depth-layers.md` — OWASP K8s Top 10 2022 ↔ 2025 매핑 혼동

[OWASP 공식](https://owasp.org/www-project-kubernetes-top-ten/) 2025 버전 기준 4건 정정:

| 기존 (혼동) | 정정 (2025) |
|------------|------------|
| K02: Supply chain vulnerabilities | K04: Lack Of Cluster Level Policy Enforcement (Supply chain) |
| K03: Overly permissive RBAC | K02: Overly Permissive Authorization Configurations |
| K06: Broken authentication | K09: Broken Authentication Mechanisms |
| K08: Network segmentation | K05: Missing Network Segmentation Controls |

L127 "Goti 실사례에서 가장 빈도 높음" → "운영 환경에서 빈도 높음" 일반화.

frontmatter description은 이미 "2025 기반"으로 명시되어 있어 본문 매핑만 정렬.

### M3 `config-explicit-defaults.md` — Kristian Glass 출처 attribution 정정

[Glass 블로그 원문 검증 결과](https://blog.doismellburning.co.uk/twelve-factor-config-misunderstandings-and-advice/) "config sprawl" 표현 부재. 부속 설명을 실제 블로그 내용("12-factor config 함정 정리")로 교체.

본문 내 "config sprawl" 용어 자체는 자체 사용 패턴이라 유지.

## Test plan

- [ ] CI: validate-rules-drift / validate-agent-handoff / inventory-labels 통과
- [ ] 외부 링크 spot-check (OWASP 2025 / Glass blog)
- [ ] M5의 4개 안티패턴 본문이 정정된 헤딩과 일관되는지 리뷰어 확인

## 검증 출처

- https://owasp.org/www-project-kubernetes-top-ten/ — K01-K10 2025 정확한 매핑
- https://blog.doismellburning.co.uk/twelve-factor-config-misunderstandings-and-advice/ — "config sprawl" / "configuration sprawl" 표현 부재 확인

## 후속

별도 PR로 phase-workflow.md 부재 자산(/phase-start command + sdd-template) 추가 예정.