### PR TITLE
feat(workflow): add /phase-start command and SDD template

### DIFF
--- a/.claude/commands/phase-start.md
+++ b/.claude/commands/phase-start.md
@@ -1,0 +1,131 @@
+---
+description: "Phase 기반 작업(SDD 게이트 강제) 시작. 11항목 체크리스트 출력 + Gate 1-5 흐름 안내."
+---
+
+# /phase-start
+
+대규모 작업(6개 이상 파일 변경 / API 3개 이상 / 시스템 마이그레이션)을 시작할 때 `.claude/rules/phase-workflow.md`의 Gate 1-5를 강제하는 진입점.
+
+`/phase-start`로 시작하지 않은 작업은 `.claude/rules/workflow.md`의 일반 작업 순서(EXPLORE → PLAN → IMPLEMENT → VERIFY → COMMIT)를 따른다.
+
+## 입력
+
+`$ARGUMENTS` — phase 이름 또는 번호
+
+옵션:
+- 단일 이름: `auth-refactor`
+- 번호 + 슬러그: `phase-3-multitenancy`
+- 생략: 현재 작업 컨텍스트에서 추론 (사용자 확인 필요)
+
+## 적용 대상 (rules/phase-workflow.md §"적용 대상")
+
+다음 중 하나 이상에 해당하면 `/phase-start` 사용:
+
+- 새 서비스/모듈 구현 (6개 이상 파일 변경 예상)
+- 기존 서비스 대규모 변경 (API 추가/변경 3개 이상)
+- 시스템 마이그레이션 (언어 전환, 아키텍처 변경)
+
+소규모 작업(버그 수정, 문서 수정, 설정 변경)은 사용하지 않는다.
+
+## 실행 절차
+
+### 1. Phase 컨텍스트 확정
+
+`$ARGUMENTS`로 phase 이름/번호를 받아 다음을 확정:
+- SDD 파일 경로: `docs/sdd-<phase-slug>.md` (path-scoped rule trigger와 일치)
+- Phase 시작 일자: 오늘 날짜 ($CURRENT_DATE)
+- 영향 범위 추정: 사용자에게 "변경 예상 파일 수", "API 변경 개수", "마이그레이션 여부" 확인
+
+### 2. SDD 작성 안내 (Gate 1)
+
+```
+SDD 파일을 다음 위치에 작성하십시오:
+  docs/sdd-<phase-slug>.md
+
+템플릿: .claude/templates/sdd.md.template
+
+SDD 필수 섹션:
+  - Background (왜 이 작업이 필요한가)
+  - Requirements (수락 기준)
+  - Design (API / 데이터 모델)
+  - Implementation Steps (Step별 의존성 명시)
+  - Test Strategy (단위 + 통합)
+  - Phase Gates (어느 Gate가 끝났는지 추적)
+  - Risks (예상되는 함정)
+```
+
+SDD 작성 완료 전 구현 코드 작성 금지.
+
+### 3. 체크리스트 출력
+
+```
+Phase: <phase-slug>
+시작일: $CURRENT_DATE
+
+[ ] Gate 1: SDD 작성 완료 (docs/sdd-<phase-slug>.md)
+[ ] Gate 2: SDD 리뷰 완료 (code-reviewer 에이전트 + 피드백 반영)
+[ ] Gate 3: SDD 기반 코드 구현 (Step별 순차)
+[ ] Gate 3: 코드/보안 리뷰 실행 + 피드백 반영
+[ ] Gate 4: 테스트 코드 작성 + 전체 통과 (단위 + 통합)
+[ ] Gate 5: PR 생성
+[ ] Gate 5: /review-pr 멀티 관점 리뷰
+[ ] Gate 5: Gemini 리뷰 확인 + 갭 기록 (docs/review-gaps.md)
+[ ] Gate 5: 피드백 반영 → push → merge
+[ ] main pull
+[ ] 트러블슈팅 로그 (/log-trouble) — 문제 발생 시
+```
+
+체크리스트는 SDD `## Phase Gates` 섹션에 복사하여 진행 상태를 추적한다.
+
+### 4. Gate 위반 검출
+
+Phase 진행 중 다음을 감지하면 작업을 중단하고 안내한다:
+
+| 감지 상황 | 위반 Gate | 안내 |
+|---------|----------|------|
+| SDD 없이 구현 코드 작성 시도 | Gate 1 | "SDD를 먼저 작성하십시오" |
+| SDD 리뷰 없이 구현 시작 | Gate 2 | "code-reviewer 에이전트로 SDD 리뷰 후 진행" |
+| 코드 리뷰 없이 PR 생성 시도 | Gate 3 | "기술 스택 리뷰 커맨드 실행 (/go:review, /java:review 등)" |
+| 테스트 미통과 상태 PR | Gate 4 | "테스트 실패 — PR 차단" |
+| /review-pr 미실행 머지 시도 | Gate 5 | "/review-pr 실행 후 머지" |
+
+### 5. 후속 권장
+
+- Phase 종료 시 회고: `docs/retrospective/$CURRENT_DATE-<phase-slug>.md` 작성 권장
+- Tier 2+ dev-log 누적 시 `/promote-devlog`로 ADR/skill 정착
+- Phase 간 SDD가 dependency를 가지면 SDD frontmatter `depends_on:`로 명시
+
+## 사용 예시
+
+```
+/phase-start auth-refactor
+→ Phase: auth-refactor
+→ 시작일: 2026-05-12
+→ SDD 작성 안내: docs/sdd-auth-refactor.md
+→ 11항목 체크리스트 출력
+→ Gate 1 대기
+```
+
+```
+/phase-start phase-3-multitenancy
+→ Phase: phase-3-multitenancy
+→ 시작일: 2026-05-12
+→ SDD 작성 안내: docs/sdd-phase-3-multitenancy.md
+→ 11항목 체크리스트 출력
+→ Gate 1 대기
+```
+
+## 안전 장치
+
+- `/phase-start`를 호출하지 않은 채 SDD 파일만 생성하면 path-scoped rule이 자동 로딩되지만 Gate 추적은 수동
+- Phase 종료(merge) 후에도 SDD는 보존 (히스토리)
+- 동시에 여러 Phase 진행 불가 — 1 Phase 1 PR 원칙
+
+## 관련 파일
+
+- Phase Gate 규칙: `.claude/rules/phase-workflow.md`
+- SDD 템플릿: `.claude/templates/sdd.md.template`
+- 일반 작업 순서: `.claude/rules/workflow.md`
+- PR 리뷰: `/review-pr`
+
+오늘 날짜: $CURRENT_DATE

--- a/.claude/rules/phase-workflow.md
+++ b/.claude/rules/phase-workflow.md
@@ -44,7 +44,7 @@ Phase 기반 작업 시 반드시 따라야 할 게이트 규칙.
 ## Gate 1: SDD 작성 (MANDATORY)
 
 - SDD(Software Design Document)를 먼저 작성한다
-- 템플릿: `docs/templates/sdd-template.md` (범용) 또는 도메인 특화 템플릿
+- 템플릿: `.claude/templates/sdd.md.template` (범용) 또는 도메인 특화 템플릿
 - SDD에 "구현 순서" 섹션이 명확해야 한다 (Step별 의존성 포함)
 - SDD에 "테스트 전략" 섹션이 있어야 한다
 
@@ -124,7 +124,7 @@ Phase 진행 중 문제 발생 시:
 
 ## 관련 파일
 
-- 범용 SDD 템플릿: `docs/templates/sdd-template.md`
+- 범용 SDD 템플릿: `.claude/templates/sdd.md.template`
 - 일반 작업 순서: `.claude/rules/workflow.md`
 - 디버깅 프로토콜: `.claude/rules/debugging.md`
 - PR 리뷰 프로세스: `.claude/rules/code-review.md`

--- a/.claude/templates/sdd.md.template
+++ b/.claude/templates/sdd.md.template
@@ -1,0 +1,162 @@
+---
+phase: {phase-slug}
+date: {YYYY-MM-DD}
+status: {draft|review|approved|implementing|merged}
+owner: {@user}
+related:
+  - adr/{NNNN-...}.md
+  - dev-logs/{YYYY-MM-DD-...}.md
+depends_on: []
+---
+
+# SDD: {Phase 제목 — 동사형 / 명확한 목표}
+
+> Software Design Document. `.claude/rules/phase-workflow.md` Gate 1-5 강제 대상.
+> 이 문서가 없으면 코드 구현 금지. 작성 후 `code-reviewer` 에이전트 리뷰 필수 (Gate 2).
+
+---
+
+## 1. Background
+
+> 왜 이 작업이 필요한가? 어떤 비즈니스/기술 force 가 있는가?
+
+- **트리거**: {장애 / 신규 기능 요구 / 마이그레이션 / 컴플라이언스}
+- **영향 범위**: {repo / 서비스 / 모듈 / 사용자 수}
+- **현재 상태의 문제**: {정량적 표현 — RPS, 비용, SLO 위반 등}
+- **관련 ADR**: {ADR-NNNN 링크 — 이 SDD 가 어떤 결정을 구현하는가}
+
+---
+
+## 2. Requirements (수락 기준)
+
+### Functional Requirements
+
+- [ ] **FR1**: {기능 요구 — 검증 가능한 형태로}
+- [ ] **FR2**: {...}
+- [ ] **FR3**: {...}
+
+### Non-Functional Requirements
+
+- [ ] **NFR1**: SLO — 예: p99 < 200ms, 에러율 < 0.1%
+- [ ] **NFR2**: 비용 — 예: 월 $X 이하
+- [ ] **NFR3**: 보안 — 예: PIPA 24h breach notification 대응 가능
+- [ ] **NFR4**: 호환성 — 예: 기존 API v1 무중단 유지
+
+### Out of Scope
+
+> 이 Phase 에서 다루지 않는 것 — 명시적으로 제외.
+
+- {나중에 별도 Phase 로 할 작업}
+
+---
+
+## 3. Design
+
+### 3.1 Architecture Overview
+
+```
+{ASCII 다이어그램 또는 mermaid — 컴포넌트 간 관계}
+```
+
+### 3.2 API Spec
+
+| Method | Path | Request | Response | 인증 |
+|--------|------|---------|----------|------|
+| POST | /api/v1/X | {schema} | {schema} | JWT |
+| GET | /api/v1/X/:id | - | {schema} | JWT |
+
+신규/변경 API 만 기술. 기존 API 영향 시 §4 Migration 에 명시.
+
+### 3.3 Data Model
+
+| 테이블/컬렉션 | 변경 | 마이그레이션 필요 |
+|-------------|------|----------------|
+| {name} | 신규 / 컬럼 추가 / 인덱스 추가 | Yes/No |
+
+스키마 변경은 `migration/expand-contract-pattern.md` skill 적용 (online migration).
+
+### 3.4 외부 의존
+
+- {외부 API / 메시지 큐 / DB / 캐시 — 추가/변경 항목만}
+
+---
+
+## 4. Implementation Steps
+
+> Step 별 의존성 명시. 병렬 가능한 Step 은 같은 column.
+
+| Step | 작업 | 의존성 | 추정 | 검증 방법 |
+|------|------|--------|------|---------|
+| S1 | {DB 마이그레이션 — expand 단계} | - | 1h | 마이그레이션 PR merge + sanity query |
+| S2 | {API 핸들러 구현} | S1 | 4h | unit test |
+| S3 | {Contract test 추가} | S2 | 2h | CDC 통과 |
+| S4 | {feature flag 도입} | S2 | 1h | flag toggle 검증 |
+| S5 | {부하 테스트} | S2, S3 | 2h | NFR1 통과 |
+| S6 | {expand-contract: contract 단계 — 옛 컬럼 제거} | S5 후 안정화 1주 | 30m | 별도 마이그레이션 PR |
+
+**Phase 내 작업 단위는 PR 1-2 개로 압축**. Step 이 5개 이상이면 Phase 를 분할 권장.
+
+---
+
+## 5. Test Strategy
+
+### 5.1 단위 테스트
+
+- {대상 함수 / 클래스} — 시나리오 N 개 (happy / edge / error)
+- 목표 커버리지: 핵심 비즈니스 로직 95%+
+
+### 5.2 통합 테스트
+
+- 외부 의존: {DB / Redis / Kafka} — TestContainers 사용
+- 데이터 시드: {프리셋}
+
+### 5.3 부하 테스트 (NFR 검증 필요 시)
+
+- 도구: {K6 / Gatling / nGrinder}
+- 시나리오: {ramp-up profile, target RPS, 지속 시간}
+- 합격 기준: §2 NFR1 충족
+
+### 5.4 Negative Path / Chaos (선택)
+
+- 외부 의존 실패 시 동작 — `testing/negative-path-coverage.md` skill
+- 다운스트림 지연 / 5xx / timeout
+
+---
+
+## 6. Phase Gates
+
+> 진행 상태 추적. `/phase-start <slug>` 출력과 동일 항목. 각 Gate 완료 시 체크.
+
+- [ ] **Gate 1**: SDD 작성 완료 (이 문서)
+- [ ] **Gate 2**: SDD 리뷰 완료 (code-reviewer 에이전트 + 피드백 반영)
+- [ ] **Gate 3**: 코드 구현 + 코드 리뷰 + 피드백 반영
+- [ ] **Gate 4**: 테스트 작성 + 전체 통과 (§5)
+- [ ] **Gate 5**: PR 생성 + /review-pr + Gemini 비교 + 머지
+
+---
+
+## 7. Risks & Mitigation
+
+| ID | 위험 | 확률 | 영향 | 완화책 |
+|----|------|------|------|--------|
+| R1 | {예: 마이그레이션 중 lock contention} | 중 | 고 | online migration (gh-ost / pg_repack) |
+| R2 | {예: 외부 API rate limit} | 고 | 중 | circuit breaker + retry budget |
+| R3 | {예: 신규 의존성 보안 취약점} | 저 | 고 | govulncheck + dependabot |
+
+---
+
+## 8. Rollback Plan
+
+- **무중단 롤백**: feature flag off
+- **데이터 마이그레이션 롤백**: expand-contract `migration/expand-contract-pattern.md` — contract 단계 되돌리기
+- **PR 단위 롤백**: `git revert <merge-sha>` + 재배포
+- **모니터링**: 롤백 후 정상화 메트릭 확인
+
+---
+
+## 9. References
+
+- 관련 ADR: `docs/adr/{NNNN}-...md`
+- 관련 dev-logs: `docs/dev-logs/{YYYY-MM-DD-...}.md`
+- 관련 skill: `.claude/skills/{도메인}/{이름}.md`
+- 외부 자료: {vendor docs / paper / blog}


### PR DESCRIPTION
## Summary

PR #20 직후 검증에서 발견된 `phase-workflow.md` rule의 부재 자산 2종을 추가하여 Phase 게이트를 실제로 실행 가능하게 만든다.

- `/phase-start` 커맨드 (Phase 진입점 + 11항목 체크리스트)
- SDD 표준 템플릿 (Background / Requirements / Design / Steps / Test / Gates / Risks)

## Why

`phase-workflow.md` (PR #20에서 추가됨)이 다음 자산을 참조하지만 둘 다 부재했음:
- `/phase-start` 커맨드 (`.claude/commands/phase-start.md`)
- SDD 템플릿 (`docs/templates/sdd-template.md`)

결과: rule이 path-scoped 자동 로딩되지만, Gate 1-5 흐름을 시작할 수단이 없어 사실상 비활성. 이 PR로 실효화.

## Changes

### `.claude/commands/phase-start.md` (신규, 131줄)

- 입력: `\$ARGUMENTS` (phase 이름/번호)
- 적용 대상: 6+ 파일 변경 / API 3+ 추가/변경 / 시스템 마이그레이션
- 출력: 11항목 체크리스트 + SDD 위치 안내 + Gate 1-5 흐름
- Gate 위반 감지 매트릭스 (SDD 없이 구현 / 코드 리뷰 없이 PR / 테스트 미통과 / /review-pr 미실행)

### `.claude/templates/sdd.md.template` (신규, 162줄)

9 섹션 표준 구조:
1. Background — 트리거, 영향, 관련 ADR
2. Requirements — FR / NFR / Out of Scope
3. Design — API Spec / Data Model / 외부 의존
4. Implementation Steps — Step별 의존성 표 (병렬 가능 식별)
5. Test Strategy — 단위 / 통합 / 부하 / Negative Path
6. Phase Gates — Gate 1-5 체크박스
7. Risks & Mitigation
8. Rollback Plan — feature flag, expand-contract, git revert
9. References — ADR / dev-logs / skill

`migration/expand-contract-pattern.md`, `testing/negative-path-coverage.md` 등 PR #18 skill과 cross-reference.

### `.claude/rules/phase-workflow.md` (수정, 2줄)

reference 경로를 `docs/templates/sdd-template.md` → `.claude/templates/sdd.md.template`로 갱신. 다른 5개 template(`.claude/templates/X.md.template`)과 위치 일관성.

## Test plan

- [ ] CI: validate-rules-drift / validate-agent-handoff / inventory-labels 통과 (로컬 검증 완료)
- [ ] `/phase-start` 커맨드가 description 매칭으로 skill 자동 등록 확인 (로컬에서 자동 등록 검증됨)
- [ ] phase-workflow.md path-scoped trigger (`sdd-*.md`, `phase-start*`)와 SDD 파일 명명 컨벤션(`docs/sdd-<phase>.md`) 일치 확인

## 후속 (이번 PR 범위 밖)

- 다른 PR #20 commands(where, related, promote-devlog 등)와 함께 `manifest.yml` 일괄 등록 (현재 7개 모두 미등록 상태 — 별개 정리 작업)
- SDD 도메인 특화 변형 추가 (예: SDD-database-migration, SDD-feature-flag) — 사용 사례 누적 후 검토