### PR TITLE
docs: add session log and fix AGENTS.md skill count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -292,7 +292,7 @@ EXPLORE/PLAN 생략한 multi-file 변경 금지.
 | Plugins | `plugins/*.yml` | `install.sh --plugin <name>` |
 | Workflows | `.claude/workflows/*.yml` | `install.sh --workflow <name>` |
 
-자산 통계: [.claude/inventory.yml](.claude/inventory.yml). 현재 273 skills (inventory.yml 의 259 + 폴더형 SKILL.md 14 — script 카운트 차이) / 49 agents / 43 commands / 12 plugins / 11 workflows. `scripts/generate-inventory.sh` 로 자동 재생성.
+자산 통계: [.claude/inventory.yml](.claude/inventory.yml). 현재 274 skills (inventory.yml 의 260 + 폴더형 SKILL.md 14 — script 카운트 차이) / 49 agents / 43 commands / 12 plugins / 11 workflows. `scripts/generate-inventory.sh` 로 자동 재생성.
 
 **신규 skill / agent 작성 표준**: [`.claude/templates/SKILL-SPEC.md`](.claude/templates/SKILL-SPEC.md) / [`AGENT-SPEC.md`](.claude/templates/AGENT-SPEC.md). frontmatter / description 패턴 / Verification Criteria 섹션 강제.
 

--- a/docs/dev-logs/sessions/2026-05-17-session.md
+++ b/docs/dev-logs/sessions/2026-05-17-session.md
@@ -1,0 +1,41 @@
+---
+date: 2026-05-17
+type: session-summary
+---
+
+# Session Summary — 2026-05-17
+
+## Activities
+
+- [research] Claude Code 효율적 사용법 외부 리서치 — Anthropic 「2026 Agentic Coding Trends Report」(18p / 8 trends) 정독, 공식 docs·engineering 블로그·논문 큐레이션 수집
+- [decision] ress-claude-agents agent 49개를 2026 리포트 기준 점검 — scope "표준 + 검증 인프라 보강" 선택 (신규 자동 준수, 기존 critical만 우선 + 점진)
+- [meta] AGENT-SPEC.md에 Permission Boundary·Escalation 섹션 + Verification Criteria self-verification 표준 추가
+- [meta] validate-skill-frontmatter.sh — agent 본문 H2 3섹션 검증 + LEGACY 화이트리스트(신규 hard / 레거시 soft) 게이트화
+- [meta] git-workflow.md — gh pr create / git push 워크플로우를 "메인 에이전트 승인 후 실행 초안"으로 재작성, user-approval.md 모순 해소
+- [troubleshoot] command substitution 서브셸에서 SOFT_WARNINGS 전역 배열 유실 → process substitution while 본체로 이동
+- [review] PR #28 멀티 관점 리뷰(보안 / 운영 / 패턴) → 9 CR 발견·전부 반영
+- [troubleshoot] CR-009(VERBOSE 분리) 적용 중 set -e 회귀(`[[ ]] && cmd` 마지막 명령) → 명시적 if로 수정
+- [troubleshoot] CI drift 2건(inventory.yml outdated, .codex adapter) → 재생성
+- [meta] AGENTS.md skill 통계 정정 (L295 273→274 / inventory 259→260, L16과 일치)
+- [implement] dev-log 2026-05-17-agent-permission-boundary.md 작성, 본 세션 로그 작성
+
+## Key Changes
+
+- `.claude/templates/AGENT-SPEC.md` — Permission Boundary·Escalation 표준, Verification self-check, §8 예시 보강
+- `scripts/validate-skill-frontmatter.sh` — 본문 3섹션 검증 + LEGACY 화이트리스트(48개) + VERBOSE 플래그
+- `.claude/agents/git-workflow.md` — 역할 경계·Permission Boundary·Escalation·Verification Criteria 4섹션, PR 생성 블록 재작성
+- `docs/dev-logs/2026-05-17-agent-permission-boundary.md` — 신규 dev-log (meta / tier 2)
+- `.claude/inventory.yml` / `.codex/agents/git-workflow.toml` — 재생성
+- `AGENTS.md` — skill 통계 정정 (273→274)
+
+## Logs Created
+
+- `docs/dev-logs/2026-05-17-agent-permission-boundary.md` (meta category — `/log-meta` 형식)
+- 본 세션 로그
+
+## Notes
+
+- **PR**: #28 (feat + docs + fix×2, merge `c4f793f`) — main 머지 완료
+- **검증 상태**: CI 5/5 통과 (Test / Docs / Inventory / Shellcheck / Drift). `validate-skill-frontmatter.sh agents` 49/49 PASS + WARN 144 (레거시 soft)
+- **후속 작업**: G2~G6 점진 마이그레이션 — agent별 Escalation·Verification 섹션 추가 후 LEGACY 화이트리스트에서 제거 시 자동 hard 전환. G4(라우팅 혼란) / G5(effort·구조) / G6(context isolation)은 AGENT-SPEC 가이드 보강 후 점진
+- **학습**: rule ≠ agent 정의 — 전달 경로가 다르다 (rule은 메인 세션 자동 로딩, subagent는 자기 정의 파일이 system prompt). bash 함정 2종(command substitution 서브셸 / set -e + `[[ ]] && cmd`)이 한 스크립트에서 연달아 발생 — dev-log §핵심 결정 3·4


### PR DESCRIPTION
## Summary
- docs/dev-logs/sessions/2026-05-17-session.md 추가 — PR #28(agent 권한 경계 표준화) 작업 세션 요약
- AGENTS.md L295 skill 통계 정정: 273→274 (inventory 259→260) — L16 및 inventory.yml 실측(260)과 일치. 2026-05-15 dev-log의 generate-inventory SKILL.md 미계산 drift

## Test plan
- [x] validate-rules-drift.sh all — exit 0
- [x] generate-inventory.sh / generate-inventory-labels.sh validate — exit 0
- [x] generate-docs.sh validate — exit 0 (errors 0, warnings 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)